### PR TITLE
Add runtime configuration for API base URL in Next.js setup

### DIFF
--- a/aquarium-ui/app/config.ts
+++ b/aquarium-ui/app/config.ts
@@ -1,2 +1,6 @@
+import getConfig from "next/config";
+
+const { publicRuntimeConfig } = getConfig() || { publicRuntimeConfig: {} };
+
 export const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+  publicRuntimeConfig.apiUrl || "http://localhost:3000";

--- a/aquarium-ui/next.config.ts
+++ b/aquarium-ui/next.config.ts
@@ -6,6 +6,14 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
+  // Enable runtime configuration
+  experimental: {
+    appDocumentPreloading: true,
+  },
+  // Configure environment variables that can be accessed at runtime
+  publicRuntimeConfig: {
+    apiUrl: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000",
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request includes changes to the runtime configuration and environment variables in the `aquarium-ui` project. The most important changes are the addition of runtime configuration support and the adjustment of the API base URL to use the runtime configuration.

Runtime configuration improvements:

* [`aquarium-ui/app/config.ts`](diffhunk://#diff-af203ddb3574d2069608420eed02da43837112dece5a4e186f0688234d63c56aR1-R6): Added support for `getConfig` from `next/config` and adjusted the `API_BASE_URL` to use `publicRuntimeConfig.apiUrl`.
* [`aquarium-ui/next.config.ts`](diffhunk://#diff-d4c9da202cb01f4aa8e1786cb792d552a6f889842348278d46e26a05151c9033R9-R16): Enabled runtime configuration by adding `experimental.appDocumentPreloading` and setting up `publicRuntimeConfig` to include `apiUrl`.