### PR TITLE
Refactor LayoutRoot and store imports to simplify code structure

### DIFF
--- a/aquarium-ui/app/components/LayoutRoot.tsx
+++ b/aquarium-ui/app/components/LayoutRoot.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Container } from "@mui/material";
 import { ReactNode } from "react";
 import StoreProvider from "../StoreProvider";
 import ThemeRegistry from "../ThemeRegistry";

--- a/aquarium-ui/app/store/store.ts
+++ b/aquarium-ui/app/store/store.ts
@@ -1,16 +1,8 @@
 import { configureStore } from "@reduxjs/toolkit";
-import aquariumsReducer, {
-  type AquariumsState,
-} from "@/app/store/aquariumsSlice";
-import lightsReducer, { type LightsState } from "@/app/store/lightsSlice";
-import sunReducer, { type SunState } from "@/app/store/sunSlice";
+import aquariumsReducer from "@/app/store/aquariumsSlice";
+import lightsReducer from "@/app/store/lightsSlice";
+import sunReducer from "@/app/store/sunSlice";
 import configReducer from "./configSlice";
-
-interface AppState {
-  aquariums: AquariumsState;
-  lights: LightsState;
-  sun: SunState;
-}
 
 export const store = configureStore({
   reducer: {


### PR DESCRIPTION
This pull request includes changes to improve the codebase by removing unnecessary imports and simplifying the state management in the `aquarium-ui` project. The most important changes are:

### Codebase simplification:

* [`aquarium-ui/app/components/LayoutRoot.tsx`](diffhunk://#diff-d6f058627761b657e7d794d09f6365c58b07c2736d6ea1b59349001eb67c9648L3): Removed the unused import of `Container` from `@mui/material`.
* [`aquarium-ui/app/store/store.ts`](diffhunk://#diff-adec676691c5472404a64522bf6a684a330e16176640a735ea1e56a88744b4dbL2-L14): Removed the type definitions for `AquariumsState`, `LightsState`, and `SunState` as they were no longer needed, and simplified the import statements for the reducers.